### PR TITLE
Fix: Save only mails that were indeed sent

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,5 +1,6 @@
 # 0.3.1
 * Aufräum Job hinzugefügt um ältere Nachrichten zu löschen
+* Nur Mails speichern, die tatsächlich gesendet wurden
 
 # 0.3.0
 * Kompatiblität zu 6.4

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,5 +1,6 @@
 # 0.3.1
 * Cleanup job added to delete older messages
+* Save only mails that were indeed sent
 
 # 0.3.0
 * Add compatibility for Shopware 6.4

--- a/src/Services/MailSender.php
+++ b/src/Services/MailSender.php
@@ -39,9 +39,10 @@ class MailSender extends AbstractMailSender
 
     public function send(Email $email, ?Envelope $envelope = null): void
     {
-        $this->saveMail($email);
-
+        // let first send the mail itself, to see if it was really sent or entered error state
         $this->mailSender->send($email, $envelope);
+
+        $this->saveMail($email);
     }
 
     private function saveMail(Email $message): void


### PR DESCRIPTION
With this commit, only mails gets saved which were really sent out.

If it gets sent before saving it, we ensure that twig syntax in mail template is correct (render template exception) and the smarthost hasn't encountered any problems (send exception) with that mail.