### PR TITLE
fix: remove duplicated loading of content when resetting the filter

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
@@ -97,8 +97,6 @@ Component.register('frosh-mail-archive-index', {
                 customerId: null,
                 term: null
             };
-
-            this.getList();
         }
     },
 


### PR DESCRIPTION
loading is handled by the `watch`