### PR TITLE
bugfix: check acl for correct permission

### DIFF
--- a/src/Resources/app/administration/src/component/notification-sw-admin/index.js
+++ b/src/Resources/app/administration/src/component/notification-sw-admin/index.js
@@ -2,9 +2,13 @@ const {Component, State} = Shopware;
 const {Criteria} = Shopware.Data;
 
 Component.override('sw-admin', {
-    inject: ['repositoryFactory'],
+    inject: ['repositoryFactory', 'acl'],
 
     async created() {
+        if (!this.acl.can('frosh_mail_archive:read')) {
+            return;
+        }
+
         const repository = this.repositoryFactory.create('frosh_mail_archive');
 
         const criteria = new Criteria();

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/index.js
@@ -14,13 +14,17 @@ Shopware.Module.register('frosh-mail-archive', {
     routes: {
         list: {
             component: 'frosh-mail-archive-index',
-            path: 'list'
+            path: 'list',
+            meta: {
+                privilege: 'frosh_mail_archive:read'
+            },
         },
         detail: {
             component: 'frosh-mail-archive-detail',
             path: 'detail/:id',
             meta: {
-                parentPath: 'frosh.mail.archive.list'
+                parentPath: 'frosh.mail.archive.list',
+                privilege: 'frosh_mail_archive:read'
             },
             props: {
                 default: ($route) => {

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/index.js
@@ -35,7 +35,8 @@ Shopware.Module.register('frosh-mail-archive', {
             group: 'plugins',
             to: 'frosh.mail.archive.list',
             icon: 'regular-envelope',
-            name: 'frosh-mail-archive.title'
+            name: 'frosh-mail-archive.title',
+            privilege: 'frosh_mail_archive:read'
         }
     ]
 });


### PR DESCRIPTION
When a role does not have the correct permissions then you get the shopware popup about missing permissions (`frosh_mail_archive:read`). Also the settings panel is displayed but can not be used as you do not have the correct permissions. 

This PR tries to alleviate the above;

1. Ensures the initial repository search is only done if permission `frosh_mail_archive:read` is allowed.
2. Ensures the settings navigation item is only rendered if permission `frosh_mail_archive:read` is allowed.
3. Ensures the settings pages are only accessible via route if permission `frosh_mail_archive:read` is allowed.

A possible future improvement would be to include a proper acl for the frosh_mail_archive detail actions (resend, hide the customer button etc). But is out of scope for this PR - which was to remove the permissions missing popups and unusable settings navigation items.