### PR TITLE
remove test trunk temporarily

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,8 @@ jobs:
                 - "~6.5.3.0"
                 - "~6.5.4.0"
                 - "~6.5.5.0"
-                - "dev-trunk"
+                - "~6.5.6.0"
+                - "~6.5.7.0"
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Sadly, there is no `6.5.x` for `shopware/core` :-( 