### PR TITLE
feat: increase subject field length to 998 to comply with RFC

### DIFF
--- a/src/Content/MailArchive/MailArchiveDefinition.php
+++ b/src/Content/MailArchive/MailArchiveDefinition.php
@@ -43,7 +43,7 @@ class MailArchiveDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
             (new JsonField('sender', 'sender'))->addFlags(new Required()),
             (new JsonField('receiver', 'receiver'))->addFlags(new Required())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
-            (new StringField('subject', 'subject'))->addFlags(new Required())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new StringField('subject', 'subject', 998))->addFlags(new Required())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new LongTextField('plainText', 'plainText'))->addFlags(new AllowHtml()),
             (new LongTextField('htmlText', 'htmlText'))->addFlags(new AllowHtml(), new SearchRanking(SearchRanking::LOW_SEARCH_RANKING)),
             (new StringField('eml_path', 'emlPath', 2048)),

--- a/src/Migration/Migration1713775973AlterSubjectFieldLength.php
+++ b/src/Migration/Migration1713775973AlterSubjectFieldLength.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\MailArchive\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1713775973AlterSubjectFieldLength extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1713775973;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `frosh_mail_archive` MODIFY `subject` VARCHAR(998) NOT NULL;');
+    }
+
+    public function updateDestructive(Connection $connection): void {}
+}


### PR DESCRIPTION
RFC 2822 section 2.1.1 "Line Length Limits" states:
> There are two limits that this standard places on the number of characters in a line. Each line of characters MUST be no more than 998 characters, and SHOULD be no more than 78 characters, excluding the CRLF.

https://datatracker.ietf.org/doc/html/rfc2822#section-2.1.1

fixes #68