### PR TITLE
Take the send history into account in the transportState filter

### DIFF
--- a/src/Content/MailArchive/MailArchiveDefinition.php
+++ b/src/Content/MailArchive/MailArchiveDefinition.php
@@ -4,6 +4,8 @@ namespace Frosh\MailArchive\Content\MailArchive;
 
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
@@ -15,6 +17,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentFkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
@@ -39,6 +43,11 @@ class MailArchiveDefinition extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+
+            new ParentFkField(self::class),
+            new ParentAssociationField(self::class, 'id'),
+            new ChildrenAssociationField(self::class),
+
             (new JsonField('sender', 'sender'))->addFlags(new Required()),
             (new JsonField('receiver', 'receiver'))->addFlags(new Required())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new StringField('subject', 'subject', 998))->addFlags(new Required())->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
@@ -47,6 +56,7 @@ class MailArchiveDefinition extends EntityDefinition
             (new LongTextField('eml', 'eml'))->addFlags(new AllowHtml()),
             (new StringField('eml_path', 'emlPath', 2048)),
             (new StringField('transport_state', 'transportState'))->addFlags(new Required()),
+            new BoolField('history_last_mail', 'historyLastMail'),
 
             (new OneToManyAssociationField('attachments', MailArchiveAttachmentDefinition::class, 'mail_archive_id', 'id'))->addFlags(new CascadeDelete()),
 
@@ -55,10 +65,6 @@ class MailArchiveDefinition extends EntityDefinition
 
             new FkField('customerId', 'customerId', CustomerDefinition::class),
             new ManyToOneAssociationField('customer', 'customerId', CustomerDefinition::class, 'id', true),
-
-            new FkField('source_mail_id', 'sourceMailId', self::class),
-            new ManyToOneAssociationField('sourceMail', 'source_mail_id', self::class, 'id', false),
-            new OneToManyAssociationField('sourceMails', self::class, 'sourceMailId')
         ]);
     }
 }

--- a/src/Content/MailArchive/MailArchiveEntity.php
+++ b/src/Content/MailArchive/MailArchiveEntity.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Frosh\MailArchive\Content\MailArchive;
 
@@ -26,6 +28,8 @@ class MailArchiveEntity extends Entity
 
     protected ?string $transportState;
 
+    protected bool $historyLastMail;
+
     /**
      * @deprecated will not be filled anyone. Use emlPath instead
      */
@@ -44,11 +48,11 @@ class MailArchiveEntity extends Entity
     /** @var EntityCollection<MailArchiveAttachmentEntity>|null $attachments */
     protected ?EntityCollection $attachments = null;
 
-    protected ?string $sourceMailId;
+    protected ?string $parentId;
 
-    protected ?MailArchiveEntity $sourceMail;
+    protected ?self $parent = null;
 
-    protected ?MailArchiveCollection $sourceMails = null;
+    protected ?MailArchiveCollection $children = null;
 
 
     /**
@@ -195,25 +199,6 @@ class MailArchiveEntity extends Entity
         $this->attachments = $attachments;
     }
 
-    public function getSourceMailId(): ?string
-    {
-        return $this->sourceMailId;
-    }
-
-    public function setSourceMailId(string $sourceMailId): void
-    {
-        $this->sourceMailId = $sourceMailId;
-    }
-
-    public function getSourceMail(): ?MailArchiveEntity
-    {
-        return $this->sourceMail;
-    }
-
-    public function setSourceMail(MailArchiveEntity $sourceMail): void
-    {
-        $this->sourceMail = $sourceMail;
-    }
 
     public function getTransportState(): ?string
     {
@@ -225,13 +210,43 @@ class MailArchiveEntity extends Entity
         $this->transportState = $transportState;
     }
 
-    public function getSourceMails(): ?MailArchiveCollection
+    public function isHistoryLastMail(): bool
     {
-        return $this->sourceMails;
+        return $this->historyLastMail;
     }
 
-    public function setSourceMails(MailArchiveCollection $sourceMails): void
+    public function setHistoryLastMail(bool $historyLastMail): void
     {
-        $this->sourceMails = $sourceMails;
+        $this->historyLastMail = $historyLastMail;
+    }
+
+    public function getParentId(): ?string
+    {
+        return $this->parentId;
+    }
+
+    public function setParentId(?string $parentId): void
+    {
+        $this->parentId = $parentId;
+    }
+
+    public function getParent(): ?MailArchiveEntity
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?MailArchiveEntity $parent): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getChildren(): ?MailArchiveCollection
+    {
+        return $this->children;
+    }
+
+    public function setChildren(MailArchiveCollection $children): void
+    {
+        $this->children = $children;
     }
 }

--- a/src/Migration/Migration1727448352AlterTable.php
+++ b/src/Migration/Migration1727448352AlterTable.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\MailArchive\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1727448352AlterTable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1727448352;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'ALTER TABLE `frosh_mail_archive` CHANGE `source_mail_id` `parent_id` binary(16) NULL;'
+        );
+
+        $connection->executeStatement(
+            'ALTER TABLE `frosh_mail_archive` ADD `history_last_mail` TINYINT(1) NOT NULL DEFAULT 0 AFTER `transport_state`;'
+        );
+
+        // set history_last_mail column of last row of history
+        $result = $connection->executeQuery(
+            'SELECT `id` FROM `frosh_mail_archive` WHERE `parent_id` IS NULL'
+        );
+        foreach ($result->iterateColumn() as $id) {
+            $lastId = $connection->fetchOne(
+                'SELECT `id` FROM `frosh_mail_archive` WHERE `parent_id` = :parentId ORDER BY created_at DESC LIMIT 1',
+                ['parentId' => $id]
+            );
+
+            if ($lastId === false) {
+                // mail was not resend
+                $criteria = ['id' => $id];
+            } else {
+                $criteria = ['id' => $lastId];
+            }
+            $connection->update(
+                'frosh_mail_archive',
+                ['history_last_mail' => 1],
+                $criteria
+            );
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/component/frosh-mail-resend-history/frosh-mail-resend-history.html.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/component/frosh-mail-resend-history/frosh-mail-resend-history.html.twig
@@ -1,4 +1,7 @@
-<sw-card :title="$tc('frosh-mail-archive.detail.resend-grid.title')">
+<sw-card
+        :title="$tc('frosh-mail-archive.detail.resend-grid.title')"
+         position-identifier="frosh-mail-archive-resend-history"
+>
     <template #grid>
         <sw-data-grid
             :isLoading="isLoading"

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/component/frosh-mail-resend-history/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/component/frosh-mail-resend-history/index.js
@@ -3,7 +3,7 @@ import template from './frosh-mail-resend-history.html.twig';
 
 Shopware.Component.register('frosh-mail-resend-history', {
     props: {
-        sourceMailId: {
+        parentMailId: {
             required: true,
             type: String
         },
@@ -46,8 +46,8 @@ Shopware.Component.register('frosh-mail-resend-history', {
         async loadMails() {
             const criteria = new Criteria();
             criteria.addFilter(Criteria.multi('OR', [
-                Criteria.equals('id', this.sourceMailId),
-                Criteria.equals('sourceMailId', this.sourceMailId)
+                Criteria.equals('id', this.parentMailId),
+                Criteria.equals('parentId', this.parentMailId)
             ]));
             criteria.addSorting(Criteria.sort('createdAt', 'DESC'));
 

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
@@ -44,8 +44,13 @@
                                v-if="archive.salesChannel" :disabled="true"
                                v-model="archive.salesChannel.name"></sw-text-field>
             </sw-card>
-            <frosh-mail-resend-history :key="resendKey" :currentMailId="archive.id"
-                                       :sourceMailId="archive.sourceMailId ?? archive.id"/>
+
+            <frosh-mail-resend-history
+                    :key="resendKey"
+                    :currentMailId="archive.id"
+                    :parentMailId="archive.parentId ?? archive.id"
+            />
+
             <sw-card
                 :title="$tc('frosh-mail-archive.detail.content.title')"
                 position-identifier="frosh-mail-archive-content"

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/frosh-mail-archive-index.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/frosh-mail-archive-index.twig
@@ -24,21 +24,25 @@
             </template>
 
             <template slot="column-createdAt" slot-scope="{ item }">
-                {{ item.createdAt | date({hour: '2-digit', minute: '2-digit', second: '2-digit'}) }}
+                <router-link :to="{ name: 'frosh.mail.archive.detail', params: { id: item.id } }">
+                    {{ item.createdAt | date({hour: '2-digit', minute: '2-digit', second: '2-digit'}) }}
+                </router-link>
             </template>
 
             <template slot="column-transportState" slot-scope="{ item }">
+
+                {{ translateState(item.transportState) }}
+
                 <template v-if="item.transportState === 'failed'">
                     <sw-icon
-                        name="regular-exclamation-triangle"
-                        color="#f00"
-                        class="frosh-mail-archive__data-grid-danger-icon"
-                        v-tooltip="{
-                            message: $tc('frosh-mail-archive.list.columns.transportFailed')
-                        }"
-                        small></sw-icon>
+                            name="regular-exclamation-triangle"
+                            color="#f00"
+                            class="frosh-mail-archive__data-grid-danger-icon"
+                            v-tooltip="{ message: $tc('frosh-mail-archive.list.columns.transportFailed') }"
+                            small
+                    ></sw-icon>
                 </template>
-                {{ translateState(item.transportState) }}
+
             </template>
 
             <template slot="detail-action" slot-scope="{ item }">
@@ -72,6 +76,17 @@
                 :placeholder="$tc('frosh-mail-archive.list.sidebar.filters.transportStatePlaceholder')"
                 :options="transportStateOptions"
             ></sw-single-select>
+
+            <sw-switch-field
+                    {% if VUE3 %}
+                        v-model:value="filter.onlyLastMailInHistory"
+                    {% else %}
+                        v-model="filter.onlyLastMailInHistory"
+                    {% endif %}
+                    :label="$tc('frosh-mail-archive.list.sidebar.filters.onlyLastMailInHistoryLabel')"
+                    :helpText="$tc('frosh-mail-archive.list.sidebar.filters.onlyLastMailInHistoryHelpText')"
+            >
+            </sw-switch-field>
 
             <sw-entity-single-select
                 v-model="filter.salesChannelId"

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
@@ -29,8 +29,9 @@ Component.register('frosh-mail-archive-index', {
                 salesChannelId: null,
                 transportState: null,
                 customerId: null,
-                term: null
-            }
+                term: null,
+                onlyLastMailInHistory: false,
+            },
         }
     },
 
@@ -90,6 +91,7 @@ Component.register('frosh-mail-archive-index', {
         translateState(state) {
             return this.$tc(`frosh-mail-archive.state.${state}`);
         },
+
         getList() {
             this.isLoading = true;
 
@@ -98,6 +100,10 @@ Component.register('frosh-mail-archive-index', {
 
             if (this.filter.transportState) {
                 criteria.addFilter(Criteria.equals('transportState', this.filter.transportState));
+            }
+
+            if (this.filter.onlyLastMailInHistory) {
+                criteria.addFilter(Criteria.equals('historyLastMail', true));
             }
 
             if (this.filter.salesChannelId) {

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/de-DE.json
@@ -25,6 +25,8 @@
                     "salesChannel": "Verkaufskanal",
                     "transportStateLabel": "Status",
                     "transportStatePlaceholder": "Status auswählen",
+                    "onlyLastMailInHistoryLabel": "Sendeverlauf berücksichtigen",
+                    "onlyLastMailInHistoryHelpText": "Wenn aktiv, wird nur die letzte Mail des Sendungsverlaufs berücksichtigt",
                     "resetFilter": "Filter zurücksetzen"
                 }
             }

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/en-GB.json
@@ -25,6 +25,8 @@
                     "salesChannel": "Sales Channel",
                     "transportStateLabel": "State",
                     "transportStatePlaceholder": "Select state",
+                    "onlyLastMailInHistoryLabel": "Consider (re)send history",
+                    "onlyLastMailInHistoryHelpText": "If active, only the last email in the (re)send history is taken into consideration",
                     "resetFilter": "Reset filter"
                 }
             }

--- a/src/Subscriber/MailArchiveDeleteSubscriber.php
+++ b/src/Subscriber/MailArchiveDeleteSubscriber.php
@@ -1,22 +1,30 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Frosh\MailArchive\Subscriber;
 
 use Frosh\MailArchive\Content\MailArchive\MailArchiveDefinition;
 use Frosh\MailArchive\Services\EmlFileManager;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeDeleteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NorFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class MailArchiveDeleteSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EntityRepository $froshMailArchiveRepository,
-        private readonly EmlFileManager   $emlFileManager
-    )
-    {
+        private readonly EmlFileManager $emlFileManager
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -35,7 +43,7 @@ class MailArchiveDeleteSubscriber implements EventSubscriberInterface
         }
 
         $criteria = new Criteria($ids);
-        $criteria->addFields(['emlPath']);
+        $criteria->addFields(['emlPath', 'parentId']);
         $mails = $this->froshMailArchiveRepository->search($criteria, $event->getContext())->getEntities();
 
         /** @var PartialEntity $mail */
@@ -47,5 +55,57 @@ class MailArchiveDeleteSubscriber implements EventSubscriberInterface
 
             $this->emlFileManager->deleteEmlFile($emlPath);
         }
+
+        $this->updateHistoryLastMail($ids, $mails, $event->getContext());
+    }
+
+    /**
+     * @param array<string> $deleteIds
+     * @param EntityCollection<PartialEntity> $mails
+     */
+    public function updateHistoryLastMail(array $deleteIds, EntityCollection $mails, Context $context): void
+    {
+        // determine last email in email history
+        $parentIds = [];
+        /** @var PartialEntity $mail */
+        foreach ($mails->getElements() as $mail) {
+            /** @var string|null $parentId */
+            $parentId = $mail->get('parentId');
+            if ($parentId !== null) {
+                $parentIds[$parentId] = $parentId;
+            }
+        }
+
+        /** @var array<string> $ids */
+        $ids = [];
+        foreach ($parentIds as $parentId) {
+            $criteria = (new Criteria())
+                ->setLimit(1)
+                ->addSorting(new FieldSorting('createdAt', FieldSorting::DESCENDING))
+                ->addFilter(
+                    new OrFilter([
+                        new EqualsFilter('id', $parentId),
+                        new EqualsFilter('parentId', $parentId),
+                    ]),
+                    new NorFilter([
+                        new EqualsAnyFilter('id', $deleteIds),
+                    ])
+                );
+
+            /** @var array<string> $tmpIds */
+            $tmpIds = $this->froshMailArchiveRepository->searchIds($criteria, $context)->getIds();
+
+            $ids = [...$ids, ...$tmpIds];
+        }
+        if (empty($ids)) {
+            return;
+        }
+
+        $payload = array_map(fn ($id) => [
+            'id' => $id,
+            'historyLastMail' => true,
+        ], $ids);
+
+        $this->froshMailArchiveRepository->update($payload, $context);
     }
 }


### PR DESCRIPTION
- Add filter on frosh-mail-archive-index.twig
- add/fix of router-link on createdAt column in frosh-mail-archive-index.twig
- add missing positionIdentifier to card in frosh-mail-resend-history.html.twig
- Refactoring of sourceMail/sourceMails to parent/children

Follow up feature from PR https://github.com/FriendsOfShopware/FroshPlatformMailArchive/pull/84