### PR TITLE
fix: Attachments show up correctly again now

### DIFF
--- a/src/Content/MailArchive/MailArchiveException.php
+++ b/src/Content/MailArchive/MailArchiveException.php
@@ -39,7 +39,7 @@ class MailArchiveException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::INVALID_UUID_CODE,
             'Parameter "{{parameter}}" is not a valid UUID',
-            ['parameter' => $parameter]
+            ['parameter' => $parameter],
         );
     }
 

--- a/src/Content/MailArchive/MailArchiveException.php
+++ b/src/Content/MailArchive/MailArchiveException.php
@@ -11,6 +11,7 @@ class MailArchiveException extends HttpException
 {
     public const NOT_FOUND_CODE = 'MAIL_ARCHIVE__NOT_FOUND';
     public const MISSING_PARAMETER_CODE = 'MAIL_ARCHIVE__MISSING_PARAMETER';
+    public const INVALID_UUID_CODE = 'MAIL_ARCHIVE__PARAMETER_INVALID_UUID';
     public const UNREADABLE_EML_CODE = 'MAIL_ARCHIVE__UNREADABLE_EML';
 
     public static function notFound(): self
@@ -29,6 +30,16 @@ class MailArchiveException extends HttpException
             self::MISSING_PARAMETER_CODE,
             'Parameter "{{parameter}}" is missing',
             ['parameter' => $parameter],
+        );
+    }
+
+    public static function parameterInvalidUuid(string $parameter): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_UUID_CODE,
+            'Parameter "{{parameter}}" is not a valid UUID',
+            ['parameter' => $parameter]
         );
     }
 

--- a/src/Controller/Api/MailArchiveController.php
+++ b/src/Controller/Api/MailArchiveController.php
@@ -43,9 +43,7 @@ class MailArchiveController extends AbstractController
         private readonly AbstractMailSender $mailSender,
         private readonly RequestStack       $requestStack,
         private readonly EmlFileManager     $emlFileManager,
-    )
-    {
-    }
+    ) {}
 
     #[Route(path: '/api/_action/frosh-mail-archive/resend-mail', name: 'api.action.frosh-mail-archive.resend-mail')]
     public function resend(Request $request, Context $context): JsonResponse
@@ -267,7 +265,7 @@ class MailArchiveController extends AbstractController
      */
     private function getFileName(array $fileNameParts): string
     {
-        return (string)preg_replace(
+        return (string) preg_replace(
             '/[\x00-\x1F\x7F-\xFF]/',
             '',
             \implode(' ', $fileNameParts),

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
@@ -5,32 +5,32 @@
 
     <template #smart-bar-actions>
         <sw-button variant="ghost" v-if="archive && archive.customer" @click="openCustomer">
-            {{ $tc('frosh-mail-archive.detail.toolbar.customer') }}
+            {{ $t('frosh-mail-archive.detail.toolbar.customer') }}
         </sw-button>
 
-        <sw-button-process :isLoading="downloadIsLoading" :processSuccess="downloadIsSuccessful" @click="downloadMail"
-                           @process-finish="downloadFinish">
-            {{ $tc('frosh-mail-archive.detail.toolbar.downloadEml') }}
+        <sw-button-process :isLoading="downloadIsLoading" :process-success="downloadIsSuccessful" @click="downloadMail"
+                           @update:process-success="downloadFinish">
+            {{ $t('frosh-mail-archive.detail.toolbar.downloadEml') }}
         </sw-button-process>
 
         <sw-button-process :isLoading="resendIsLoading" :processSuccess="resendIsSuccessful" @click="resendMail"
-                           @process-finish="resendFinish">
-            {{ $tc('frosh-mail-archive.detail.toolbar.resend') }}
+                           @update:process-success="resendFinish">
+            {{ $t('frosh-mail-archive.detail.toolbar.resend') }}
         </sw-button-process>
     </template>
 
     <template #content>
         <sw-card-view v-if="archive">
             <sw-alert
-                v-if="archive.transportState === 'failed'"
-                variant="warning"
-                class="frosh-mail-archive__detail-alert"
+                    v-if="archive.transportState === 'failed'"
+                    variant="warning"
+                    class="frosh-mail-archive__detail-alert"
             >
-                {{ $tc('frosh-mail-archive.detail.alert.transportFailed') }}
+                {{ $t('frosh-mail-archive.detail.alert.transportFailed') }}
             </sw-alert>
             <sw-card
-                :title="$tc('frosh-mail-archive.detail.metadata.title')"
-                position-identifier="frosh-mail-archive-metadata"
+                    :title="$t('frosh-mail-archive.detail.metadata.title')"
+                    position-identifier="frosh-mail-archive-metadata"
             >
                 <sw-text-field :label="$tc('frosh-mail-archive.detail.metadata.sentDate')" :disabled="true"
                                v-model="createdAtDate"></sw-text-field>
@@ -47,40 +47,50 @@
             <frosh-mail-resend-history :key="resendKey" :currentMailId="archive.id"
                                        :sourceMailId="archive.sourceMailId ?? archive.id"/>
             <sw-card
-                :title="$tc('frosh-mail-archive.detail.content.title')"
-                position-identifier="frosh-mail-archive-content"
+                    :title="$t('frosh-mail-archive.detail.content.title')"
+                    position-identifier="frosh-mail-archive-content"
             >
                 <h4>HTML</h4>
                 <iframe :src="htmlText" sandbox frameborder="0"></iframe>
 
                 <h4>Plain</h4>
                 <iframe :src="plainText" sandbox frameborder="0"></iframe>
-
-                <h4>Attachments: {{ archive.attachments.length }}</h4>
-
-                <sw-data-grid
-                    v-if="archive.attachments.length > 0"
-                    :showSelection="false"
-                    :dataSource="archive.attachments"
-                    :columns="attachmentsColumns"
-                >
-                    <template #column-fileSize="{ item }">
-                        <template v-if="item.fileSize < 0">
-                            unknown
+            </sw-card>
+            <sw-card :title="$t('frosh-mail-archive.detail.attachments.title')"
+                     position-identifier="frosh-mail-archive-attachments"
+            >
+                <template #grid>
+                    <sw-card-section v-if="archive.transportState === 'pending' || archive.attachments.length === 0"
+                                     secondary divider="bottom">
+                        <sw-alert variant="warning" v-if="archive.transportState === 'pending'">
+                            {{ $t('frosh-mail-archive.detail.attachments.attachments-incomplete-alert') }}
+                        </sw-alert>
+                        <sw-alert v-if="archive.attachments.length === 0">
+                            {{ $t('frosh-mail-archive.detail.attachments.no-attachments-alert') }}
+                        </sw-alert>
+                    </sw-card-section>
+                    <sw-data-grid
+                            :showSelection="false"
+                            :dataSource="archive.attachments"
+                            :columns="attachmentsColumns"
+                    >
+                        <template #column-fileSize="{ item }">
+                            <template v-if="item.fileSize < 0">
+                                {{ $t('frosh-mail-archive.detail.attachments.size-unknown') }}
+                            </template>
+                            <template v-else>
+                                {{ formatSize(item.fileSize) }}
+                            </template>
                         </template>
-                        <template v-else>
-                            {{ formatSize(item.fileSize) }}
+
+                        <template #actions="{ item }">
+                            <sw-context-menu-item class="sw-entity-listing__context-menu-show-action"
+                                                  @click="downloadAttachment(item.id)">
+                                {{ $t('frosh-mail-archive.detail.attachments.download') }}
+                            </sw-context-menu-item>
                         </template>
-                    </template>
-
-                    <template #actions="{ item }">
-                        <sw-context-menu-item class="sw-entity-listing__context-menu-show-action"
-                                              @click="downloadAttachment(item.id)">
-                            Download
-                        </sw-context-menu-item>
-                    </template>
-
-                </sw-data-grid>
+                    </sw-data-grid>
+                </template>
             </sw-card>
         </sw-card-view>
     </template>

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/index.js
@@ -85,17 +85,17 @@ Component.register('frosh-mail-archive-detail', {
             return [
                 {
                     property: 'fileName',
-                    label: 'Name',
+                    label: this.$t('frosh-mail-archive.detail.attachments.file-name'),
                     rawData: true
                 },
                 {
                     property: 'fileSize',
-                    label: 'Size',
+                    label: this.$t('frosh-mail-archive.detail.attachments.size'),
                     rawData: true
                 },
                 {
                     property: 'contentType',
-                    label: 'ContentType',
+                    label: this.$t('frosh-mail-archive.detail.attachments.type'),
                     rawData: true
                 }
             ];

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/de-DE.json
@@ -51,6 +51,16 @@
             "content": {
                 "title": "Inhalt"
             },
+            "attachments": {
+                "title": "Anhänge",
+                "size-unknown": "unbekannt",
+                "download": "Herunterladen",
+                "size": "Dateigröße",
+                "file-name": "Name",
+                "type": "MIME type",
+                "no-attachments-alert": "Diese E-Mail enthält keine Anhänge.",
+                "attachments-incomplete-alert": "Möglicherweise werden nicht alle Anhänge angezeigt, während die E-Mail im \"ausstehend\" Status ist."
+            },
             "alert": {
                 "transportFailed": "E-Mail-Versand fehlgeschlagen. Bitte überprüfe deine Mailer-Einstellungen und versuche es erneut."
             },

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/snippet/en-GB.json
@@ -51,6 +51,16 @@
             "content": {
                 "title": "Content"
             },
+            "attachments": {
+                "title": "Attachments",
+                "size-unknown": "unknown",
+                "download": "Download",
+                "size": "File size",
+                "file-name": "Name",
+                "type": "MIME type",
+                "no-attachments-alert": "This mail does not contain any attachments.",
+                "attachments-incomplete-alert": "Some attachments might not show up while the mail is in pending state."
+            },
             "alert": {
                 "transportFailed": "Mail delivery failed. Please check mailer settings and try again."
             },

--- a/src/Services/MailSender.php
+++ b/src/Services/MailSender.php
@@ -70,7 +70,7 @@ class MailSender extends AbstractMailSender
                 'sender' => [$message->getFrom()[0]->getAddress() => $message->getFrom()[0]->getName()],
                 'receiver' => $this->convertAddress($message->getTo()),
                 'subject' => $message->getSubject(),
-                'plainText' => nl2br((string)$message->getTextBody()),
+                'plainText' => nl2br((string) $message->getTextBody()),
                 'htmlText' => $message->getHtmlBody(),
                 'emlPath' => $emlPath,
                 'salesChannelId' => $this->getCurrentSalesChannelId(),

--- a/src/Subscriber/MailTransportSubscriber.php
+++ b/src/Subscriber/MailTransportSubscriber.php
@@ -23,9 +23,7 @@ class MailTransportSubscriber implements EventSubscriberInterface
     public function __construct(
         private readonly EntityRepository $froshMailArchiveRepository,
         private readonly EmlFileManager   $emlFileManager,
-    )
-    {
-    }
+    ) {}
 
     public static function getSubscribedEvents(): array
     {
@@ -66,7 +64,7 @@ class MailTransportSubscriber implements EventSubscriberInterface
         $this->froshMailArchiveRepository->update([[
             'id' => $archiveId,
             'transportState' => $newState,
-            'attachments' => $attachments
+            'attachments' => $attachments,
         ]], $context);
 
     }
@@ -79,7 +77,7 @@ class MailTransportSubscriber implements EventSubscriberInterface
             return [
                 'fileName' => $attachment->getFilename(),
                 'contentType' => $attachment->getContentType(),
-                'fileSize' => strlen($attachment->getBody())
+                'fileSize' => strlen($attachment->getBody()),
             ];
         }, $attachments);
     }

--- a/src/Subscriber/MailTransportSubscriber.php
+++ b/src/Subscriber/MailTransportSubscriber.php
@@ -51,7 +51,7 @@ class MailTransportSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $context = Context::createCLIContext();
+        $context = Context::createDefaultContext();
         $archiveId = $this->getArchiveIdByMessage($message);
 
         if (!$archiveId) {
@@ -69,13 +69,17 @@ class MailTransportSubscriber implements EventSubscriberInterface
 
     }
 
+    /**
+     * @param Email $message
+     * @return array<array{'fileName': string, 'contentType': string, 'fileSize': int}>
+     */
     private function getAttachments(Email $message): array
     {
         $attachments = $message->getAttachments();
 
         return array_map(static function (DataPart $attachment) {
             return [
-                'fileName' => $attachment->getFilename(),
+                'fileName' => $attachment->getFilename() ?? "attachment",
                 'contentType' => $attachment->getContentType(),
                 'fileSize' => strlen($attachment->getBody()),
             ];


### PR DESCRIPTION
This PR fixes #88 

Because of the way Shopware handles attachments, the attachments are not resolved before the MailTransport has run. That's why we need to save attachments in the Subscriber. 

While I was at it I also improved the UI of attachments.
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/5d3096b2-1fb1-465a-be63-a1ea8bbb24d8">
