### PR TITLE
feat: save eml into subfolders

### DIFF
--- a/src/Services/EmlFileManager.php
+++ b/src/Services/EmlFileManager.php
@@ -27,7 +27,9 @@ class EmlFileManager
             throw new \RuntimeException('Cannot compress eml file');
         }
 
-        $emlFilePath = 'mails/' . $id . '.eml.gz';
+        $folderParts = \array_slice(\str_split($id, 2), 0, 3);
+
+        $emlFilePath = 'mails/' . \implode('/', $folderParts) . '/' . $id . '.eml.gz';
 
         $this->filesystem->write($emlFilePath, $content);
 


### PR DESCRIPTION
There are filesystems having limits per directory or performance issues when too many files are in one directory.