### PR TITLE
feat: add url persistent list filters

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
@@ -100,6 +100,25 @@ Component.register('frosh-mail-archive-index', {
             return this.$tc(`frosh-mail-archive.state.${state}`);
         },
 
+        updateData(query) {
+            for (const filter in this.filter) {
+                this.filter[filter] = query[filter] ?? null;
+            }
+        },
+
+        saveFilters() {
+            this.updateRoute({
+                limit: this.limit,
+                page: this.page,
+                term: this.term,
+                sortBy: this.sortBy,
+                sortDirection: this.sortDirection,
+                naturalSorting: this.naturalSorting,
+            },
+                this.filter
+            );
+        },
+
         getList() {
             this.isLoading = true;
 
@@ -129,6 +148,7 @@ Component.register('frosh-mail-archive-index', {
                     this.items = searchResult;
                     this.total = searchResult.total;
                     this.isLoading = false;
+                    this.saveFilters();
                 });
         },
 


### PR DESCRIPTION
This adds support for the filters to remain existent after viewing the detail page of a email and going back. This is helpful because you dont need to filter each time when not using multiple tabs.