### PR TITLE
Fixed a problem with mailers that have a concurrent connection limit

### DIFF
--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
@@ -178,13 +178,18 @@ Component.register('frosh-mail-archive-index', {
             }
             this.isLoading = true;
 
-            Promise.all(ids.map((id) => {
-                return this.froshMailArchiveService.resendMail(id);
-            })).finally(async () => {
+            this.bulkResendFunc(ids).then(async () => {
                 this.$refs.table?.resetSelection();
                 await this.getList();
                 this.isLoading = false;
             });
+        },
+
+        async bulkResendFunc(ids) {
+            for (let i = 0; i < ids.length; i++) {
+                let id = ids[i];
+                await this.froshMailArchiveService.resendMail(id);
+            }
         },
 
         onSelectionChanged(selection) {


### PR DESCRIPTION
Fixed a problem with mailers that have a concurrent connection limit by making the bulk operation send mails after the first one has succeeded.

Currently there is an issue in the Bulk resend operation where it will fail by sending too many requests at once.
The mailer will return a 400 Bad Request because the connection limit is overstepped.

Solution: Make the resend mails wait for the previous to finish being sent.

Possible problems: Performance will suffer a bit since it waits for each call to finish.