### PR TITLE
Feat/send to custom mail address

### DIFF
--- a/src/Controller/Api/MailArchiveController.php
+++ b/src/Controller/Api/MailArchiveController.php
@@ -49,6 +49,7 @@ class MailArchiveController extends AbstractController
     public function resend(Request $request, Context $context): JsonResponse
     {
         $mailId = $request->request->get('mailId');
+        $emailAddress = $request->request->get('email');
 
         if (!\is_string($mailId)) {
             throw MailArchiveException::parameterMissing('mailId');
@@ -74,6 +75,10 @@ class MailArchiveController extends AbstractController
             $this->enrichFromEml($emlPath, $email);
         } else {
             $this->enrichFromDatabase($mailArchive, $email);
+        }
+
+        if($emailAddress){
+            $email->to($emailAddress);
         }
 
         $this->mailSender->send($email);

--- a/src/Controller/Api/MailArchiveController.php
+++ b/src/Controller/Api/MailArchiveController.php
@@ -77,7 +77,7 @@ class MailArchiveController extends AbstractController
             $this->enrichFromDatabase($mailArchive, $email);
         }
 
-        if($emailAddress){
+        if ($emailAddress) {
             $email->to($emailAddress);
         }
 

--- a/src/Resources/app/administration/src/init/api_client.js
+++ b/src/Resources/app/administration/src/init/api_client.js
@@ -5,7 +5,7 @@ class ApiClient extends ApiService {
         super(httpClient, loginService, apiEndpoint);
     }
 
-    resendMail(mailId) {
+    resendMail(mailId, email) {
         const headers = this.getBasicHeaders({});
 
         return this.httpClient
@@ -13,6 +13,7 @@ class ApiClient extends ApiService {
                 `_action/${this.getApiBasePath()}/resend-mail`,
                 {
                     mailId,
+                    email
                 },
                 {
                     ...this.basicConfig,

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/frosh-mail-archive-detail.twig
@@ -15,7 +15,7 @@
         <sw-button-process
             :isLoading="resendIsLoading"
             :processSuccess="resendIsSuccessful"
-            @click="resendMail"
+            @click="resendMailPreview"
             @update:process-success="resendFinish"
         >
             {{ $t('frosh-mail-archive.detail.toolbar.resend') }}
@@ -189,6 +189,27 @@
                             </sw-context-menu-item>
                         </template>
                     </sw-data-grid>
+                    {% block frosh_mail_archive_resend_modal %}
+                        <sw-modal 
+                            v-if="showResendModal" 
+                            :title="$tc('frosh-mail-archive.detail.toolbar.resend')" 
+                            :closable="true"
+                            @modal-close="closeResendModal"
+                        >
+                            <sw-email-field v-model:value="selectedEmailAdress" :label="$tc('frosh-mail-archive.detail.metadata.receiver')">
+                                {{selectedEmailAdress}}
+                            </sw-email-field>
+                            <sw-button 
+                                :disabled="false" variant="primary" 
+                                :square="false" 
+                                :block="false" 
+                                :isLoading="false"
+                                @click="resendMail(resendItem, selectedEmailAdress)"
+                            >
+                                {{$tc('frosh-mail-archive.list.actions.bulkResendAction')}}
+                            </sw-button>
+                        </sw-modal>
+                    {% endblock %}
                 </template>
             </sw-card>
         </sw-card-view>

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-detail/index.js
@@ -15,6 +15,9 @@ Component.register('frosh-mail-archive-detail', {
             downloadIsLoading: false,
             downloadIsSuccessful: false,
             resendCounter: 0,
+            selectedEmailAdress: null,
+            resendItem: null,
+            showResendModal: false
         };
     },
 
@@ -109,6 +112,14 @@ Component.register('frosh-mail-archive-detail', {
     },
 
     methods: {
+        resendMailPreview(){
+            item = this.archive
+            this.isLoading = true;
+            this.showResendModal = true;
+            const email = Object.keys(item.receiver)[0];
+            this.selectedEmailAdress = email;
+            this.resendItem = item;
+        },
         loadMail() {
             const criteria = new Criteria();
             criteria.addAssociation('attachments');
@@ -144,10 +155,8 @@ Component.register('frosh-mail-archive-detail', {
             this.downloadIsSuccessful = false;
         },
         resendMail() {
-            this.resendIsLoading = true;
-
             this.froshMailArchiveService
-                .resendMail(this.archive.id)
+                .resendMail(this.archive.id, this.selectedEmailAdress)
                 .then(() => {
                     this.resendIsSuccessful = true;
                     this.createNotificationSuccess({
@@ -173,7 +182,12 @@ Component.register('frosh-mail-archive-detail', {
                 .finally(() => {
                     this.resendIsLoading = false;
                     this.resendCounter++;
+                    this.showResendModal = false;
                 });
+        },
+        closeResendModal(){
+            this.showResendModal = false;
+            this.isLoading = false;
         },
         downloadMail() {
             this.downloadIsLoading = true;

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/frosh-mail-archive-index.twig
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/frosh-mail-archive-index.twig
@@ -60,7 +60,7 @@
                         square
                         size="small"
                         variant="context"
-                        @click="resendMail(item)"
+                        @click="resendMailPreview(item)"
                         deprecated
                     >
                         <sw-icon
@@ -83,7 +83,7 @@
                 </sw-context-menu-item>
                 <sw-context-menu-item
                     class="sw-entity-listing__context-menu-show-action"
-                    @click="resendMail(item)"
+                    @click="resendMailPreview(item)"
                 >
                     {{ $tc('frosh-mail-archive.list.actions.resendAction') }}
                 </sw-context-menu-item>
@@ -107,6 +107,27 @@
                 </a>
             </template>
         </sw-entity-listing>
+        {% block frosh_mail_archive_resend_modal %}
+            <sw-modal 
+                v-if="showResendModal" 
+                :title="$tc('frosh-mail-archive.detail.toolbar.resend')" 
+                :closable="true"
+                @modal-close="closeResendModal"
+            >
+                <sw-email-field v-model:value="selectedEmailAdress" :label="$tc('frosh-mail-archive.detail.metadata.receiver')">
+                    {{selectedEmailAdress}}
+                </sw-email-field>
+                <sw-button 
+                    :disabled="false" variant="primary" 
+                    :square="false" 
+                    :block="false" 
+                    :isLoading="false"
+                    @click="resendMail(resendItem, selectedEmailAdress)"
+                >
+                    {{$tc('frosh-mail-archive.list.actions.bulkResendAction')}}
+                </sw-button>
+            </sw-modal>
+        {% endblock %}
     </template>
 
     <template #sidebar>

--- a/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
+++ b/src/Resources/app/administration/src/module/frosh-mail-archive/page/frosh-mail-archive-index/index.js
@@ -30,6 +30,9 @@ Component.register('frosh-mail-archive-index', {
                 term: null,
             },
             selectedItems: {},
+            selectedEmailAdress: null,
+            resendItem: null,
+            showResendModal: false
         };
     },
 
@@ -93,6 +96,10 @@ Component.register('frosh-mail-archive-index', {
     },
 
     methods: {
+        closeResendModal(){
+            this.showResendModal = false;
+            this.isLoading = false;
+        },
         translateState(state) {
             return this.$tc(`frosh-mail-archive.state.${state}`);
         },
@@ -163,11 +170,16 @@ Component.register('frosh-mail-archive-index', {
                 });
         },
 
-        resendMail(item) {
+        resendMailPreview(item){
             this.isLoading = true;
-
+            this.showResendModal = true;
+            const email = Object.keys(item.receiver)[0];
+            this.selectedEmailAdress = email;
+            this.resendItem = item;
+        },
+        resendMail(item, email = Object.keys(item.receiver)[0]) {
             this.froshMailArchiveService
-                .resendMail(item.id)
+                .resendMail(item.id, email)
                 .then(async () => {
                     this.createNotificationSuccess({
                         title: this.$tc(
@@ -191,6 +203,7 @@ Component.register('frosh-mail-archive-index', {
                 })
                 .finally(() => {
                     this.isLoading = false;
+                    this.showResendModal = false;
                 });
         },
 


### PR DESCRIPTION
Added a modal with prefilled email address if resend. 

It is also changable to another address if the customer wants the email to another one. 

Im not sure how to handle the contact person, as in standard there is always also the name of the customer. Should i implement an input field for this?

Closes: #121

As always please let me know what you think, or what i can do better.